### PR TITLE
Silence redundant logging to stdout/stderr

### DIFF
--- a/bin/couchdb.tpl.in
+++ b/bin/couchdb.tpl.in
@@ -120,7 +120,7 @@ _get_pid () {
     echo $PID
 }
 
-_add_config_file () {
+_add_config_path () {
     if test -z "$print_arguments"; then
         print_arguments="$1"
     else
@@ -134,14 +134,6 @@ EOF
     background_start_arguments="$background_start_arguments -a $1"
 }
 
-_add_config_dir () {
-    for file in "$1"/*.ini; do
-        if [ -r "$file" ]; then
-          _add_config_file "$file"
-        fi
-    done
-}
-
 _add_erlang_config () {
     if [ -r "$1" ]; then
         ERL_START_OPTIONS="$ERL_START_OPTIONS -config '$1'"
@@ -149,15 +141,15 @@ _add_erlang_config () {
 }
 
 _load_config () {
-    _add_config_file "$DEFAULT_CONFIG_FILE"
-    _add_config_dir "$DEFAULT_CONFIG_DIR"
+    _add_config_path "$DEFAULT_CONFIG_FILE"
+    _add_config_path "$DEFAULT_CONFIG_DIR"
     # We initialize plugins here to get the desired default config load order
     _find_plugins
-    _add_config_file "$LOCAL_CONFIG_FILE"
-    _add_config_dir "$LOCAL_CONFIG_DIR"
+    _add_config_path "$LOCAL_CONFIG_DIR"
+    _add_config_path "$LOCAL_CONFIG_FILE"
     if [ "$COUCHDB_ADDITIONAL_CONFIG_FILE" != '' ]
     then
-        _add_config_file "$COUCHDB_ADDITIONAL_CONFIG_FILE"
+        _add_config_path "$COUCHDB_ADDITIONAL_CONFIG_FILE"
     fi
 }
 
@@ -238,7 +230,7 @@ _find_plugins () {
                 else
                     ERL_ZFLAGS="$ERL_ZFLAGS -pz '$plugin/ebin'"
                 fi
-                _add_config_dir "$plugin/priv/default.d"
+                _add_config_path "$plugin/priv/default.d"
                 _add_erlang_config "$plugin/priv/couch_plugin.config"
             fi
         done
@@ -358,8 +350,8 @@ parse_script_option_list () {
         case "$1" in
             -h) shift; display_help; exit;;
             -V) shift; display_version; exit;;
-            -a) shift; _add_config_file "$1"; shift;;
-            -A) shift; _add_config_dir "$1"; shift;;
+            -a) shift; _add_config_path "$1"; shift;;
+            -A) shift; _add_config_path "$1"; shift;;
             -n) shift; _reset_config;;
             -c) shift; _print_config; exit;;
             -i) shift; INTERACTIVE=true;;

--- a/src/couchdb/couch_log.erl
+++ b/src/couchdb/couch_log.erl
@@ -204,7 +204,7 @@ terminate(_Arg, #state{fd = Fd}) ->
     file:close(Fd).
 
 log(#state{fd = Fd}, ConsoleMsg, FileMsg) ->
-    ok = io:put_chars(ConsoleMsg),
+    %ok = io:put_chars(ConsoleMsg),
     ok = io:put_chars(Fd, FileMsg).
 
 get_log_messages(Pid, Level, Format, Args) ->

--- a/src/couchdb/couch_server_sup.erl
+++ b/src/couchdb/couch_server_sup.erl
@@ -108,6 +108,7 @@ start_server(IniFiles) ->
 
     Ip = couch_config:get("httpd", "bind_address"),
     io:format("Apache CouchDB has started. Time to relax.~n"),
+    {module, sd_notify} == code:load_file(sd_notify) andalso sd_notify:sd_notify(0, "READY=1"),
     Uris = [get_uri(Name, Ip) || Name <- [couch_httpd, https]],
     [begin
         case Uri of

--- a/src/couchdb/couch_server_sup.erl
+++ b/src/couchdb/couch_server_sup.erl
@@ -56,10 +56,12 @@ start_server(IniFiles) ->
     {ok, ConfigPid} = couch_config:start_link(IniFiles),
 
     LogLevel = couch_config:get("log", "level", "info"),
+    LogFileName = couch_config:get("log", "file"),
     % announce startup
-    io:format("Apache CouchDB ~s (LogLevel=~s) is starting.~n", [
+    io:format("Apache CouchDB ~s (LogLevel=~s) is logging to ~s.~n", [
         couch_server:get_version(),
-        LogLevel
+        LogLevel,
+        LogFileName
     ]),
     case LogLevel of
     "debug" ->


### PR DESCRIPTION
CouchDB already logs everything to /var/log/couchdb/couch.log.
The stdout/stderr redundantly floods /var/log/messages.

This temporary hack was suggested by rnewson in #couchdb.

https://issues.apache.org/jira/browse/COUCHDB-2264
Related issue
